### PR TITLE
feat(vncserver): add UseBlacklist option to config_defaults

### DIFF
--- a/modules/enableit/common/data/common.yaml
+++ b/modules/enableit/common/data/common.yaml
@@ -468,6 +468,7 @@ common::software::vncserver::config_defaults:
   session: "gnome"
   geometry: "1920x1080"
   BlacklistThreshold: "20"
+  UseBlacklist: "0"
 
 # Logging
 common::logging::logrotate::manage: true

--- a/modules/enableit/common/data/os/Ubuntu-24.04.yaml
+++ b/modules/enableit/common/data/os/Ubuntu-24.04.yaml
@@ -10,6 +10,7 @@ common::software::vncserver::config_defaults:
   geometry: "1920x1080"
   localhost: "no"
   BlacklistThreshold: "20"
+  UseBlacklist: "0"
 common::software::rustdesk::client_extra_dependencies:
   - libgtk-3-0t64
   - libasound2t64

--- a/modules/enableit/common/manifests/software/vncserver.pp
+++ b/modules/enableit/common/manifests/software/vncserver.pp
@@ -26,6 +26,7 @@ class common::software::vncserver (
       geometry           => Enum['2000x1200', '1280x1024', '1920x1080', '1920x1200'],
       localhost          => Optional[Enum['yes', 'no']],
       'BlacklistThreshold' => Optional[String],
+      'UseBlacklist'     => Optional[Enum['0', '1']],
   }]                                       $config_defaults  = {},
   Hash[String, Stdlib::Port]               $vnc_users        = {},
   Eit_types::Noop_Value                    $noop_value       = undef,

--- a/modules/enableit/profile/manifests/software/vncserver.pp
+++ b/modules/enableit/profile/manifests/software/vncserver.pp
@@ -7,6 +7,7 @@ class profile::software::vncserver (
     geometry           => Enum['2000x1200', '1280x1024', '1920x1080', '1920x1200'],
     localhost          => Optional[Enum['yes', 'no']],
     'BlacklistThreshold' => Optional[String],
+    'UseBlacklist'     => Optional[Enum['0', '1']],
   }]                                  $config_defaults = $common::software::vncserver::config_defaults,
   Hash[String, Stdlib::Port]          $vnc_users       = $common::software::vncserver::vnc_users,
   Enum['vncserver', 'tigervncserver'] $systemd_service = $common::software::vncserver::systemd_service,


### PR DESCRIPTION
Allows enabling/disabling tigervnc's login blacklist via hiera (common::software::vncserver::config_defaults), defaulting to "0".

https://gitea.obmondo.com/EnableIT/abbnoa6nlk/issues/2345