### PR TITLE
feat(s3): add write-only, no-delete S3 role support

### DIFF
--- a/modules/enableit/eit_types/types/storage/s3.pp
+++ b/modules/enableit/eit_types/types/storage/s3.pp
@@ -1,4 +1,0 @@
-type Eit_types::Storage::S3 = Hash[String, Struct[{
-  email      => Eit_types::Email,
-  access_key => String,
-}]]

--- a/modules/enableit/eit_types/types/storage/s3/readonly.pp
+++ b/modules/enableit/eit_types/types/storage/s3/readonly.pp
@@ -1,8 +1,0 @@
-type Eit_types::Storage::S3::ReadOnly = Hash[String, Struct[{
-  email      => Eit_types::Email,
-  access_key => String,
-  buckets    => Array[Struct[{
-    bucket => String,
-    owner  => String,
-  }]],
-}]]

--- a/modules/enableit/eit_types/types/storage/s3/role.pp
+++ b/modules/enableit/eit_types/types/storage/s3/role.pp
@@ -1,0 +1,9 @@
+type Eit_types::Storage::S3::Role = Hash[String, Struct[{
+  email         => Eit_types::Email,
+  access_key    => String,
+  bucket_access => Optional[Array[Struct[{
+    bucket     => String,
+    role       => Enum['read', 'write', 'readwrite', 'admin'],
+    managed_by => String,
+  }]]],
+}]]

--- a/modules/enableit/eit_types/types/storage/s3/role.pp
+++ b/modules/enableit/eit_types/types/storage/s3/role.pp
@@ -1,9 +1,7 @@
 type Eit_types::Storage::S3::Role = Hash[String, Struct[{
-  email         => Eit_types::Email,
-  access_key    => String,
-  bucket_access => Optional[Array[Struct[{
-    bucket     => String,
-    role       => Enum['read', 'write', 'readwrite', 'admin'],
-    managed_by => String,
+  email      => Eit_types::Email,
+  access_key => String,
+  owns       => Optional[Hash[String, Struct[{
+    grants => Hash[String, Enum['read', 'write', 'readwrite', 'admin']],
   }]]],
 }]]

--- a/modules/enableit/profile/manifests/storage/s3.pp
+++ b/modules/enableit/profile/manifests/storage/s3.pp
@@ -37,51 +37,49 @@ class profile::storage::s3 (
     { 'accessKey' => $_name, 'secretKey' => $_opts['access_key'] }
   }
 
-  # Build per-bucket policies grouped by (bucket, managed_by); each grant
-  # carries its own role so s3-policy-init.sh can build the right
-  # statements.
-  $_raw_policies = $roles.reduce([]) |$acc, $role| {
-    [$_name, $opts] = $role
-    $_canonical_id = seeded_rand_string(65, "${opts['email']}_${_name}")
-    $_shortid = 123456789013 + seeded_rand(999, "${opts['email']}_${_name}")
+  # Build one policy per owned bucket. Ownership is structural: the account
+  # a bucket sits under (`owns`) is the one whose credentials apply the
+  # policy (PutBucketPolicy must authenticate as an account with rights over
+  # the bucket). Each grant names a grantee account and its role level so
+  # s3-policy-init.sh can build the right statements.
+  $_bucket_policies = $roles.reduce([]) |$acc, $role| {
+    [$_owner, $owner_opts] = $role
 
-    $_entries = pick_default($opts['bucket_access'], []).reduce([]) |$inner_acc, $be| {
-      if $be['managed_by'] in $roles {
-        $inner_acc << {
-          'bucket'         => $be['bucket'],
-          'ownerAccessKey' => $be['managed_by'],
-          'ownerSecretKey' => $roles[$be['managed_by']]['access_key'],
-          'grants'         => [{
-            'accessKey'   => $_name,
-            'secretKey'   => $opts['access_key'],
-            'canonicalId' => $_canonical_id,
-            'shortid'     => String($_shortid),
-            'access'      => $be['role'],
-          }],
+    $_owned = pick_default($owner_opts['owns'], {}).reduce([]) |$bucket_acc, $bucket_entry| {
+      [$_bucket, $_spec] = $bucket_entry
+
+      $_grants = $_spec['grants'].reduce([]) |$grant_acc, $grant| {
+        [$_grantee, $_access] = $grant
+        if $_grantee in $roles {
+          $_g_opts = $roles[$_grantee]
+          $_g_seed = "${_g_opts['email']}_${_grantee}"
+          $grant_acc << {
+            'accessKey'   => $_grantee,
+            'secretKey'   => $_g_opts['access_key'],
+            'canonicalId' => seeded_rand_string(65, $_g_seed),
+            'shortid'     => String(123456789013 + seeded_rand(999, $_g_seed)),
+            'access'      => $_access,
+          }
+        } else {
+          warning("S3 bucket policy: grantee '${_grantee}' for bucket '${_bucket}' (owned by '${_owner}') not found among roles, skipping")
+          $grant_acc
         }
+      }
+
+      if empty($_grants) {
+        $bucket_acc
       } else {
-        warning("S3 bucket policy: managed_by '${be['managed_by']}' not found among roles, skipping bucket '${be['bucket']}' for '${_name}'")
-        $inner_acc
+        $bucket_acc << {
+          'bucket'         => $_bucket,
+          'ownerAccessKey' => $_owner,
+          'ownerSecretKey' => $owner_opts['access_key'],
+          'grants'         => $_grants,
+        }
       }
     }
 
-    $acc + $_entries
+    $acc + $_owned
   }
-
-  $_bucket_policies = $_raw_policies.reduce({}) |$map, $entry| {
-    $_key = "${entry['bucket']}|${entry['ownerAccessKey']}"
-    if $_key in $map {
-      $_existing = $map[$_key]
-      $map + { $_key => {
-        'bucket'         => $_existing['bucket'],
-        'ownerAccessKey' => $_existing['ownerAccessKey'],
-        'ownerSecretKey' => $_existing['ownerSecretKey'],
-        'grants'         => $_existing['grants'] + $entry['grants'],
-      }}
-    } else {
-      $map + { $_key => $entry }
-    }
-  }.values
 
   file { default:
     ensure => ensure_dir($manage),

--- a/modules/enableit/profile/manifests/storage/s3.pp
+++ b/modules/enableit/profile/manifests/storage/s3.pp
@@ -7,16 +7,14 @@ class profile::storage::s3 (
   String           $image        = $role::storage::s3::image,
   Stdlib::Unixpath $conf_dir     = $role::storage::s3::conf_dir,
 
-  Eit_types::Storage::S3 $roles = $role::storage::s3::roles,
-
-  Eit_types::Storage::S3::ReadOnly $read_only_roles = $role::storage::s3::read_only_roles,
+  Eit_types::Storage::S3::Role $roles = $role::storage::s3::roles,
 ) {
 
   # TODO: function does not work as it should
   #s3_roles($roles)
 
   # TODO: Add a check for shortid should not be a duplicate
-  $_admin_accounts = $roles.reduce([]) |$acc, $role| {
+  $_accounts = $roles.reduce([]) |$acc, $role| {
     [$_name, $opts] = $role
 
     $_shortid = 123456789013 + seeded_rand(999, "${opts['email']}_${_name}")
@@ -34,61 +32,35 @@ class profile::storage::s3 (
       }]
     }
   }
-
-  $_readonly_accounts = $read_only_roles.reduce([]) |$acc, $role| {
-    [$_name, $opts] = $role
-
-    $_shortid = 123456789013 + seeded_rand(999, "${opts['email']}_${_name}")
-    $_arn = "arn:aws:iam::${_shortid}:root"
-
-    $acc << {
-      name        => $_name,
-      canonicalID => seeded_rand_string(65, "${opts['email']}_${_name}"),
-      email       => $opts['email'],
-      arn         => $_arn,
-      shortid     => String($_shortid),
-      keys        => [{
-        'access' => $_name,
-        'secret' => $opts['access_key'],
-      }]
-    }
-  }
-
-  $_accounts = $_admin_accounts + $_readonly_accounts
 
   $_admin_creds = $roles.map |$_name, $_opts| {
     { 'accessKey' => $_name, 'secretKey' => $_opts['access_key'] }
   }
 
-  $_readonly_creds = $read_only_roles.map |$_name, $_opts| {
-    { 'accessKey' => $_name, 'secretKey' => $_opts['access_key'] }
-  }
+  # Build per-bucket policies grouped by (bucket, managed_by); each grant
+  # carries its own role so s3-policy-init.sh can build the right
+  # statements.
+  $_raw_policies = $roles.reduce([]) |$acc, $role| {
+    [$_name, $opts] = $role
+    $_canonical_id = seeded_rand_string(65, "${opts['email']}_${_name}")
+    $_shortid = 123456789013 + seeded_rand(999, "${opts['email']}_${_name}")
 
-  $_readonly_canonical_ids = $read_only_roles.map |$_name, $_opts| {
-    seeded_rand_string(65, "${_opts['email']}_${_name}")
-  }
-
-  # Build per-bucket read-only policies grouped by (bucket, owner)
-  $_raw_policies = $read_only_roles.reduce([]) |$acc, $role| {
-    [$_ro_name, $_ro_opts] = $role
-    $_ro_canonical_id = seeded_rand_string(65, "${_ro_opts['email']}_${_ro_name}")
-    $_ro_shortid = 123456789013 + seeded_rand(999, "${_ro_opts['email']}_${_ro_name}")
-
-    $_entries = $_ro_opts['buckets'].reduce([]) |$inner_acc, $be| {
-      if $be['owner'] in $roles {
+    $_entries = pick_default($opts['bucket_access'], []).reduce([]) |$inner_acc, $be| {
+      if $be['managed_by'] in $roles {
         $inner_acc << {
-          'bucket'           => $be['bucket'],
-          'ownerAccessKey'   => $be['owner'],
-          'ownerSecretKey'   => $roles[$be['owner']]['access_key'],
-          'readOnlyAccounts' => [{
-            'accessKey'   => $_ro_name,
-            'secretKey'   => $_ro_opts['access_key'],
-            'canonicalId' => $_ro_canonical_id,
-            'shortid'     => String($_ro_shortid),
+          'bucket'         => $be['bucket'],
+          'ownerAccessKey' => $be['managed_by'],
+          'ownerSecretKey' => $roles[$be['managed_by']]['access_key'],
+          'grants'         => [{
+            'accessKey'   => $_name,
+            'secretKey'   => $opts['access_key'],
+            'canonicalId' => $_canonical_id,
+            'shortid'     => String($_shortid),
+            'access'      => $be['role'],
           }],
         }
       } else {
-        warning("S3 bucket policy: owner '${be['owner']}' not found in roles, skipping bucket '${be['bucket']}' for read-only role '${$_ro_name}'")
+        warning("S3 bucket policy: managed_by '${be['managed_by']}' not found among roles, skipping bucket '${be['bucket']}' for '${_name}'")
         $inner_acc
       }
     }
@@ -101,10 +73,10 @@ class profile::storage::s3 (
     if $_key in $map {
       $_existing = $map[$_key]
       $map + { $_key => {
-        'bucket'           => $_existing['bucket'],
-        'ownerAccessKey'   => $_existing['ownerAccessKey'],
-        'ownerSecretKey'   => $_existing['ownerSecretKey'],
-        'readOnlyAccounts' => $_existing['readOnlyAccounts'] + $entry['readOnlyAccounts'],
+        'bucket'         => $_existing['bucket'],
+        'ownerAccessKey' => $_existing['ownerAccessKey'],
+        'ownerSecretKey' => $_existing['ownerSecretKey'],
+        'grants'         => $_existing['grants'] + $entry['grants'],
       }}
     } else {
       $map + { $_key => $entry }
@@ -143,10 +115,8 @@ class profile::storage::s3 (
     "${conf_dir}/s3-sideloader-config.json":
       ensure  => file,
       content => stdlib::to_json_pretty({
-        adminAccounts        => $_admin_creds,
-        readOnlyAccounts     => $_readonly_creds,
-        readOnlyCanonicalIds => $_readonly_canonical_ids,
-        bucketPolicies       => $_bucket_policies,
+        adminAccounts  => $_admin_creds,
+        bucketPolicies => $_bucket_policies,
       }).node_encrypt::secret,
     ;
     '/opt/obmondo/docker-compose/s3/s3-policy-init.sh':

--- a/modules/enableit/profile/templates/docker-compose/s3/s3-policy-init.sh.epp
+++ b/modules/enableit/profile/templates/docker-compose/s3/s3-policy-init.sh.epp
@@ -27,12 +27,38 @@ apply_policies() {
     owner_sk=$(echo "$policy" | jq -r '.ownerSecretKey')
     POLICY=$(echo "$policy" | jq --arg bucket "$bucket" '{
       "Version": "2012-10-17",
-      "Statement": [.readOnlyAccounts[] | {
-        "Effect": "Allow",
-        "Principal": {"AWS": [.shortid]},
-        "Action": ["s3:GetObject", "s3:ListBucket"],
-        "Resource": ["arn:aws:s3:::" + $bucket, "arn:aws:s3:::" + $bucket + "/*"]
-      }]
+      "Statement": (
+        [.grants[] | select(.access == "read" or .access == "readwrite") | {
+          "Effect": "Allow",
+          "Principal": {"AWS": [.shortid]},
+          "Action": ["s3:GetObject"],
+          "Resource": ["arn:aws:s3:::" + $bucket + "/*"]
+        }]
+        + [.grants[] | select(.access == "read") | {
+          "Effect": "Allow",
+          "Principal": {"AWS": [.shortid]},
+          "Action": ["s3:ListBucket"],
+          "Resource": ["arn:aws:s3:::" + $bucket]
+        }]
+        + [.grants[] | select(.access == "write" or .access == "readwrite") | {
+          "Effect": "Allow",
+          "Principal": {"AWS": [.shortid]},
+          "Action": ["s3:PutObject"],
+          "Resource": ["arn:aws:s3:::" + $bucket + "/*"]
+        }]
+        + [.grants[] | select(.access == "write" or .access == "readwrite") | {
+          "Effect": "Allow",
+          "Principal": {"AWS": [.shortid]},
+          "Action": ["s3:ListBucket", "s3:GetBucketVersioning"],
+          "Resource": ["arn:aws:s3:::" + $bucket]
+        }]
+        + [.grants[] | select(.access == "admin") | {
+          "Effect": "Allow",
+          "Principal": {"AWS": [.shortid]},
+          "Action": ["s3:*"],
+          "Resource": ["arn:aws:s3:::" + $bucket, "arn:aws:s3:::" + $bucket + "/*"]
+        }]
+      )
     }')
 
     export AWS_ACCESS_KEY_ID="$owner_ak"

--- a/modules/enableit/role/manifests/storage/s3.pp
+++ b/modules/enableit/role/manifests/storage/s3.pp
@@ -9,9 +9,55 @@
 #
 # @param conf_dir The Unix path to the configuration directory.
 #
-# @param roles The S3 storage roles.
+# @param roles
+#   All S3 accounts, keyed by name. `bucket_access` is optional (omit it
+#   entirely for an account with nothing to declare - e.g. a plain identity
+#   that only ever acts as another entry's `managed_by`). For every
+#   `bucket_access` entry, `managed_by` names the account whose credentials
+#   get used to actually apply that bucket's policy (the S3 PutBucketPolicy
+#   call has to be authenticated as an account with rights over that
+#   bucket - typically its real owner), and `role` is the grant level
+#   applied for the entry's own account:
+#   - `read`: `s3:GetObject` + `s3:ListBucket`.
+#   - `write`: `s3:PutObject` + `s3:ListBucket` + `s3:GetBucketVersioning`
+#     - no `s3:GetObject`, the account genuinely can't read existing
+#     content.
+#   - `readwrite`: everything `write` grants, plus `s3:GetObject` - needed
+#     by replication clients (e.g. RustFS) that HEAD/GET the destination
+#     object before uploading, which `write` alone can't satisfy.
+#   - `admin`: full access (`s3:*`) on the bucket - the broadest grant,
+#     not a claim of ownership; `managed_by` still names whose
+#     credentials apply the policy.
 #
-# @param read_only_roles The S3 read-only storage roles.
+#   `managed_by` must match the name of an account declared here,
+#   otherwise that bucket_access entry is skipped with a warning.
+#
+# @example Hiera
+#   role::storage::s3::roles:
+#     app:
+#       access_key: ENC[PKCS7,...]
+#       email: app@example.com
+#     backup-exporter:
+#       access_key: ENC[PKCS7,...]
+#       email: backup-exporter@example.com
+#       bucket_access:
+#         - bucket: app-logs-backup
+#           role: read
+#           managed_by: app
+#     upload-only:
+#       access_key: ENC[PKCS7,...]
+#       email: upload-only@example.com
+#       bucket_access:
+#         - bucket: app-uploads
+#           role: write
+#           managed_by: app
+#     replication-backup:
+#       access_key: ENC[PKCS7,...]
+#       email: replication-backup@example.com
+#       bucket_access:
+#         - bucket: app-uploads
+#           role: readwrite
+#           managed_by: app
 #
 # @param manage Whether to manage the S3 storage resources. Defaults to true.
 #
@@ -24,14 +70,13 @@
 # @groups network endpoint.
 #
 class role::storage::s3 (
-  Stdlib::Fqdn                     $endpoint,
-  Stdlib::Unixpath                 $data_dir,
-  Stdlib::Unixpath                 $metadata_dir,
-  Stdlib::Unixpath                 $conf_dir,
-  Eit_types::Storage::S3           $roles,
-  Eit_types::Storage::S3::ReadOnly $read_only_roles,
-  Boolean                          $manage = true,
-  String                           $image  = 'zenko/cloudserver:latest-7.10.19',
+  Stdlib::Fqdn               $endpoint,
+  Stdlib::Unixpath           $data_dir,
+  Stdlib::Unixpath           $metadata_dir,
+  Stdlib::Unixpath           $conf_dir,
+  Eit_types::Storage::S3::Role $roles,
+  Boolean                    $manage = true,
+  String                     $image  = 'zenko/cloudserver:latest-7.10.19',
 ) inherits role::storage {
 
   contain role::virtualization::docker

--- a/modules/enableit/role/manifests/storage/s3.pp
+++ b/modules/enableit/role/manifests/storage/s3.pp
@@ -10,14 +10,13 @@
 # @param conf_dir The Unix path to the configuration directory.
 #
 # @param roles
-#   All S3 accounts, keyed by name. `bucket_access` is optional (omit it
-#   entirely for an account with nothing to declare - e.g. a plain identity
-#   that only ever acts as another entry's `managed_by`). For every
-#   `bucket_access` entry, `managed_by` names the account whose credentials
-#   get used to actually apply that bucket's policy (the S3 PutBucketPolicy
-#   call has to be authenticated as an account with rights over that
-#   bucket - typically its real owner), and `role` is the grant level
-#   applied for the entry's own account:
+#   All S3 accounts, keyed by name. `owns` is optional (omit it entirely for
+#   an account that owns no buckets - e.g. a plain grantee identity). Under
+#   `owns`, each key is a bucket the account owns: its credentials apply that
+#   bucket's policy (the S3 PutBucketPolicy call has to be authenticated as
+#   an account with rights over the bucket - the owner). Ownership is
+#   therefore structural, not a separate field. Each bucket's `grants` maps a
+#   grantee account name to the grant level applied for it:
 #   - `read`: `s3:GetObject` + `s3:ListBucket`.
 #   - `write`: `s3:PutObject` + `s3:ListBucket` + `s3:GetBucketVersioning`
 #     - no `s3:GetObject`, the account genuinely can't read existing
@@ -25,39 +24,33 @@
 #   - `readwrite`: everything `write` grants, plus `s3:GetObject` - needed
 #     by replication clients (e.g. RustFS) that HEAD/GET the destination
 #     object before uploading, which `write` alone can't satisfy.
-#   - `admin`: full access (`s3:*`) on the bucket - the broadest grant,
-#     not a claim of ownership; `managed_by` still names whose
-#     credentials apply the policy.
+#   - `admin`: full access (`s3:*`) on the bucket - the broadest grant.
 #
-#   `managed_by` must match the name of an account declared here,
-#   otherwise that bucket_access entry is skipped with a warning.
+#   Each grantee name must match an account declared here, otherwise that
+#   grant is skipped with a warning.
 #
 # @example Hiera
 #   role::storage::s3::roles:
 #     app:
 #       access_key: ENC[PKCS7,...]
 #       email: app@example.com
+#       owns:
+#         app-logs-backup:
+#           grants:
+#             backup-exporter: read
+#         app-uploads:
+#           grants:
+#             upload-only: write
+#             replication-backup: readwrite
 #     backup-exporter:
 #       access_key: ENC[PKCS7,...]
 #       email: backup-exporter@example.com
-#       bucket_access:
-#         - bucket: app-logs-backup
-#           role: read
-#           managed_by: app
 #     upload-only:
 #       access_key: ENC[PKCS7,...]
 #       email: upload-only@example.com
-#       bucket_access:
-#         - bucket: app-uploads
-#           role: write
-#           managed_by: app
 #     replication-backup:
 #       access_key: ENC[PKCS7,...]
 #       email: replication-backup@example.com
-#       bucket_access:
-#         - bucket: app-uploads
-#           role: readwrite
-#           managed_by: app
 #
 # @param manage Whether to manage the S3 storage resources. Defaults to true.
 #


### PR DESCRIPTION
Adds a third role type alongside admin (roles) and read_only_roles: write_only_roles, which grants only s3:PutObject on specific buckets owned by another account, with no read/list/delete access.