### PR TITLE
fix: remove dangling functions::knockout call in site.pp

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -2,8 +2,6 @@
 # https://github.com/puppetlabs/puppetlabs-puppet_agent/blob/caaa52fb3d080f277243c6e78ce842df71cdd146/manifests/install.pp#L191
 $platform_tag = undef
 
-# Remove any classes that start with the knockout prefix `!!`. I'm not sure if
-# this is smart...
 $obmondo_classes = lookup('classes', Array[String], undef, [])
 
 # Check if the given class is role::monitoring only.


### PR DESCRIPTION
PR #35 (removed_knockout) deleted the functions::knockout function and its supporting config, but missed this call site, breaking catalog compilation with "Unknown function: 'functions::knockout'" on every environment that reaches this code path. Per that PR's own stated intent, knockout-prefix filtering is no longer needed here - drop the call and use the raw classes lookup.