### PR TITLE
Bump linuxaid-cli to 1.8.0

### DIFF
--- a/modules/enableit/common/data/architectures/aarch64.yaml
+++ b/modules/enableit/common/data/architectures/aarch64.yaml
@@ -1,8 +1,8 @@
 ---
 common::system::openvox::linuxaid_cli::checksums:
+  1.8.0: eb6d5e2c877f337cbd6e04dbadeb54726f53759b2caa4fa5a461915bbca9954f
+  1.7.0: 6dd8736e94b59141fe2069a36c84e78c91c86038eb21ea8856cc19ebddc028a1
   1.6.0: 0eef03d0b022551283d8bfa4ff027433a54c368c19f36f81e4c1b5b3a6590c4a
-  1.5.0: def91dfc7bb90f95cd073e1ef2fe42dc5a093c657f5333289c5dc90eb64bbc5d
-  1.4.0: fdb127f986aacf3341b9cd68e867bb3ee5d778e57d8e6b23c9d79050529dd6e4
 
 common::network::netbird::checksums:
   0.74.6: ba722ec00fbd0e2bfda31ebb37934a9a86174e6fc810cbc8bc0cae255fd76865

--- a/modules/enableit/common/data/architectures/armv7l.yaml
+++ b/modules/enableit/common/data/architectures/armv7l.yaml
@@ -23,9 +23,9 @@ common::system::openvox::package_name: "openvox"
 common::system::openvox::version: "8.24.1"
 common::system::openvox::linuxaid_cli::install_method: archive
 common::system::openvox::linuxaid_cli::checksums:
+  1.8.0: a564af283010afdbf0f0f3bdd954b6f87a9c3ba3c853d71d398f69dbb89bfd22
+  1.7.0: 2266dede063528c2c63f196be1b8eb76c0a53f1553b669e3774ad93b68801b4c
   1.6.0: 24e2427fc509326c8bac7eb392aa24364d5541e27beea4853fed2d598a55421c
-  1.5.0: 0347db8e5ce1c6f327552c9fce7ad417e37a037566dd7ff02e30bf335dfea2c6
-  1.4.0: 91f451d75c5df89aa07721eef50cacf956bd5fd36761ab11e80a9faf2852b722
 
 common::system::obmondo_admin::manage: false
 common::system::updates::enable: false

--- a/modules/enableit/common/data/common.yaml
+++ b/modules/enableit/common/data/common.yaml
@@ -306,11 +306,11 @@ common::system::openvox::configure_agent: true
 # Update other architecture checksums in their respective heira config file.
 # https://github.com/Obmondo/LinuxAid/blob/master/modules/enableit/common/data/architectures/armv7l.yaml
 common::system::openvox::linuxaid_cli::install_method: package
-common::system::openvox::linuxaid_cli::version: 1.6.0
+common::system::openvox::linuxaid_cli::version: 1.8.0
 common::system::openvox::linuxaid_cli::checksums:
+  1.8.0: fbf66f14b2d68bc297616a51291b029a9b522853e74dc3a45e5125062ca8459c
+  1.7.0: 9694a2726a0c93073af8ce47f1db0f2ba7aa86ad208a24e641cede8b1565f116
   1.6.0: 4d01213e0c43ba69a43f16b32c6784e6da64d4749b537a75f404e7db42b5e294
-  1.5.0: 8d9bd4fdfa65e53680f76db6637182632cc960a37a2c7168d84ccdb2abc05e34
-  1.4.0: ef0f044f1a731f59614ac7bad1b57a02dc2e3d2236e7309a24f4e15b94600e59
 
 ## KeepAlived
 common::system::keepalived::global_defs:


### PR DESCRIPTION
package { ensure => <version> } only re-asserts the version on the next Puppet run; it doesn't stop a manual apt/dnf/zypper upgrade from moving the package past what's pinned in hiera in between runs. Mirror the per-provider lock (apt::pin / yum::versionlock / zypprepo::versionlock) that the sibling openvox-agent package already uses in openvox.pp.

Also bump linuxaid-cli to 1.7.0 with sha256 checksums for the release assets, verified against the published checksums.txt and by re-downloading and hashing each tarball. Drop the oldest retained checksum entry (1.4.0) in each file to keep the last-3-versions convention already used here.