### PR TITLE
feat(openvox): let the agent decide the puppet environment

### DIFF
--- a/modules/enableit/profile/manifests/system/openvox.pp
+++ b/modules/enableit/profile/manifests/system/openvox.pp
@@ -8,7 +8,6 @@ class profile::system::openvox (
   Boolean              $run_agent_as_noop      = $common::system::openvox::run_agent_as_noop,
   Optional[Hash]       $extra_main_settings    = $common::system::openvox::extra_main_settings,
   String               $aio_package_name       = $common::system::openvox::package_name,
-  String               $environment            = $common::system::openvox::environment,
 
   Eit_types::Noop_Value $noop_value             = $common::system::openvox::noop_value,
   Optional[String]      $package_version_suffix = undef,
@@ -141,7 +140,6 @@ class profile::system::openvox (
       'onetime'                          => false,
       'certname'                         => $::trusted['certname'],
       'manage_internal_file_permissions' => false,
-      'environment'                      => regsubst($environment, '\.', '_', 'G'),
       'runtimeout'                       => '10m',
       'masterport'                       => $server_port,
       'extra_main_settings'              => $extra_main_settings,

--- a/modules/enableit/profile/templates/puppet.conf.epp
+++ b/modules/enableit/profile/templates/puppet.conf.epp
@@ -25,4 +25,3 @@
     splaylimit = 60s
     splay = <%= $splay %>
     usecacheonfailure = <%= $usecacheonfailure %>
-    environment = <%= $environment %>

--- a/puppet_enc.rb
+++ b/puppet_enc.rb
@@ -59,7 +59,6 @@ server_data = if TESTING
 
 subscription_product_id = server_data&.dig('product_id')
 tag_keys = server_data&.dig('tags') || []
-environment = server_data&.dig('environment')&.gsub(/[^a-zA-Z0-9]/, '_')
 
 # ensure that we don't have too many tags -- if we allow for more tags, we also
 # need to update hiera.yaml!
@@ -93,10 +92,11 @@ parameters = {
   'obmondo_tags'    => tag_keys,
 }.merge(tags)
 
+# NOTE: no 'environment' key here on purpose. An environment returned by an ENC overrides the one
+# the agent asks for, which would make `puppet agent -E <environment>` a no-op. The agent decides
+# instead: linuxaid-cli reads the environment for the node from the API and passes it to the run.
 output = {
   'parameters' => parameters
 }
-
-output['environment'] = environment
 
 puts YAML.dump(output)


### PR DESCRIPTION
Final part of the change that moves ownership of the puppet environment from the ENC to the agent.

**Do not merge until a linuxaid-cli that sends `--environment` is on every node.** See rollout below.

## Why

An environment returned by an ENC overrides the one the agent asks for. Since `puppet_enc.rb` emitted `environment` for every node, `puppet agent -t -E <environment>` never took effect — the node always compiled against whatever the API returned.

## What changes

- `puppet_enc.rb` no longer emits `environment` (with a comment saying why, so it does not come back by accident). It still emits tags, subscription and hiera parameters.
- `puppet.conf.epp` drops the `environment` line, and `profile::system::openvox` drops the now-unused `$environment` parameter.

The environment now reaches the run from linuxaid-cli, which reads it from the API (`GET /servers/environment/certname/{certname}`) and passes it as `--environment`. The default per node is still what is set in Obmondo — only the delivery path changes.

## Rollout order

1. obmondo-api-go — the GET endpoint.
2. linuxaid-cli — reads it and passes `--environment`.
3. wait for that CLI to reach every node.
4. this PR.

Landing this early means nodes get no environment from either the ENC or `puppet.conf`, and puppet falls back to its built-in `production`, which is not one of our environments.

## Left in place

`common::system::openvox::environment` and `common.yaml:294` (`v1.8.3`) still exist and now have no consumer in this repo. Removing a required class parameter and a hiera key felt riskier than leaving it, since customer hieradata may still set it — worth a follow-up decision.

## Testing

`ruby -c puppet_enc.rb` passes. The puppet CLI is not installed on my machine, so the manifest is not parser-validated — worth a `puppet parser validate` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)