### PR TITLE
Add RustFS storage support via docker-compose

### DIFF
--- a/modules/enableit/profile/manifests/storage/rustfs.pp
+++ b/modules/enableit/profile/manifests/storage/rustfs.pp
@@ -1,0 +1,45 @@
+# rustfs storage
+class profile::storage::rustfs (
+  Stdlib::Fqdn     $endpoint       = $role::storage::rustfs::endpoint,
+  Stdlib::Unixpath $data_dir       = $role::storage::rustfs::data_dir,
+  Stdlib::Unixpath $logs_dir       = $role::storage::rustfs::logs_dir,
+  String           $access_key     = $role::storage::rustfs::access_key,
+  String           $secret_key     = $role::storage::rustfs::secret_key,
+  String           $image          = $role::storage::rustfs::image,
+  Boolean          $console_enable = $role::storage::rustfs::console_enable,
+) {
+
+  file { default:
+    ensure => 'directory',
+    ;
+    [
+      '/opt/obmondo/docker-compose/rustfs',
+      $data_dir,
+      $logs_dir,
+    ]:
+    ;
+    '/opt/obmondo/docker-compose/rustfs/docker-compose.yaml':
+      ensure  => 'present',
+      content => epp('profile/docker-compose/rustfs/docker-compose.yaml.epp', {
+        endpoint       => $endpoint,
+        image          => $image,
+        data_dir       => $data_dir,
+        logs_dir       => $logs_dir,
+        access_key     => $access_key,
+        secret_key     => $secret_key,
+        console_enable => $console_enable,
+      }).node_encrypt::secret,
+      require => [
+        File['/opt/obmondo/docker-compose/rustfs'],
+      ]
+      ;
+  }
+
+  docker_compose { 'rustfs':
+    ensure        => 'present',
+    compose_files => [
+      '/opt/obmondo/docker-compose/rustfs/docker-compose.yaml',
+    ],
+    require       => File['/opt/obmondo/docker-compose/rustfs/docker-compose.yaml'],
+  }
+}

--- a/modules/enableit/profile/templates/docker-compose/rustfs/docker-compose.yaml.epp
+++ b/modules/enableit/profile/templates/docker-compose/rustfs/docker-compose.yaml.epp
@@ -1,0 +1,22 @@
+---
+version: '3'
+
+services:
+  rustfs:
+    hostname: <%= $endpoint %>
+    image: <%= $image %>
+    volumes:
+      - <%= $data_dir %>:/data/rustfs0
+      - <%= $logs_dir %>:/app/logs
+    environment:
+      - RUSTFS_VOLUMES=/data/rustfs0
+      - RUSTFS_ADDRESS=0.0.0.0:9000
+      - RUSTFS_CONSOLE_ADDRESS=0.0.0.0:9001
+      - RUSTFS_CONSOLE_ENABLE=<%= $console_enable %>
+      - RUSTFS_ACCESS_KEY=<%= $access_key %>
+      - RUSTFS_SECRET_KEY=<%= $secret_key %>
+      - RUSTFS_OBS_LOG_DIRECTORY=/app/logs
+      - RUSTFS_OBS_LOGGER_LEVEL=warn
+    ports:
+      - '127.0.0.1:9000:9000'
+      - '127.0.0.1:9001:9001'

--- a/modules/enableit/role/data/common.yaml
+++ b/modules/enableit/role/data/common.yaml
@@ -5,5 +5,12 @@ role::projectmanagement::gitlab_ci_runner::__blendable: true
 role::projectmanagement::perforce::git_connector::__blendable: true
 role::projectmanagement::perforce::icmanage::__blendable: true
 role::storage::beegfs::__blendable: true
+
+# RustFS - S3-compatible object storage, run via docker-compose.
+# endpoint, data_dir, logs_dir, access_key and secret_key have no default
+# and must be set per node.
+role::storage::rustfs::image: 'rustfs/rustfs:latest'
+role::storage::rustfs::console_enable: true
+
 role::web::haproxy::__blendable: true
 role::web::nginx::__blendable: true

--- a/modules/enableit/role/manifests/storage/rustfs.pp
+++ b/modules/enableit/role/manifests/storage/rustfs.pp
@@ -1,0 +1,37 @@
+# @summary Class for managing the RustFS Storage role
+#
+# RustFS is an S3-compatible object storage server, run via docker-compose.
+#
+# @param endpoint The FQDN of the RustFS endpoint.
+#
+# @param data_dir The Unix path to the data directory.
+#
+# @param logs_dir The Unix path to the logs directory.
+#
+# @param access_key The admin access key.
+#
+# @param secret_key The admin secret key.
+#
+# @param image The Docker image to use for RustFS. Defaults to 'rustfs/rustfs:latest'.
+#
+# @param console_enable Whether to enable the RustFS web console.
+#
+# @groups directories data_dir, logs_dir.
+#
+# @groups settings access_key, secret_key, image, console_enable.
+#
+# @groups network endpoint.
+#
+class role::storage::rustfs (
+  Stdlib::Fqdn     $endpoint,
+  Stdlib::Unixpath $data_dir,
+  Stdlib::Unixpath $logs_dir,
+  String           $access_key,
+  String           $secret_key,
+  String           $image          = 'rustfs/rustfs:latest',
+  Boolean          $console_enable = true,
+) inherits role::storage {
+
+  contain role::virtualization::docker
+  contain profile::storage::rustfs
+}


### PR DESCRIPTION
Mirrors the existing role::storage::s3 / profile::storage::s3 pattern: a role class holding required per-node hiera values (endpoint, data/log dirs, admin credentials), a profile class rendering and managing the docker-compose service, and generic defaults (image, console_enable) in role/data/common.yaml.