### PR TITLE
fix(repository/microsoft): add new Microsoft signing key for resolute mirror

### DIFF
--- a/modules/enableit/repository/data/common.yaml
+++ b/modules/enableit/repository/data/common.yaml
@@ -142,6 +142,7 @@ repository::mirror::default_configurations:
         package_format: "deb"
         key_ids:
           - "BC528686B50D79E339D3721CEB3E94ADBE1229CF"
+          - "AA86F75E427A19DD33346403EE4D7792F748182B"
     yum:
       enable: false
       el7:


### PR DESCRIPTION
- Microsoft have created a new key for repositories created after April 2025 and legacy key which we already had is associated with repositories created before May 2025
- Due to this reason, this PR is meant to add the newer key to LinuxAid
- Source - https://github.com/microsoft/linux-package-repositories#signature-verification