### PR TITLE
fix(monitor): register manual cert domains with an https scheme

### DIFF
--- a/modules/enableit/monitor/manifests/domains.pp
+++ b/modules/enableit/monitor/manifests/domains.pp
@@ -18,7 +18,10 @@ define monitor::domains (
 
   $job_name = 'probe_blackbox_domains'
   $collect_dir = '/etc/prometheus/file_sd_config.d'
-  $_domain = regsubst($domain, '^(https?://)?([^/]+)(/.*)?$', '\2', 'G').split('/')[0]
+  # Hostnames are case-insensitive; normalise so the same domain reaching us
+  # with different casing cannot produce two separate probe targets and two
+  # separate threshold recording rules.
+  $_domain = downcase(regsubst($domain, '^(https?://)?([^/]+)(/.*)?$', '\2', 'G').split('/')[0])
 
   @@prometheus::scrape_job { $_domain :
     job_name    => $job_name,

--- a/modules/enableit/profile/manifests/system/certs/manual.pp
+++ b/modules/enableit/profile/manifests/system/certs/manual.pp
@@ -68,10 +68,20 @@ define profile::system::certs::manual (
     content => $key_and_cert,
   }
 
-  $_domain = extract_common_name($cert)
+  # NOTE: monitor the domain this cert is *deployed* for, not the cert's CN.
+  # The CN is only one of the names a cert carries and is deprecated as an
+  # identifier; the hiera title is the name we actually serve on this host.
+  # Casing is normalised because CAs emit whatever casing they were asked for.
+  $_domain = downcase($domain)
 
   if $ports.empty {
-    monitor::domains { $_domain: }
+    # NOTE: the scheme is required. Given a bare hostname, blackbox scores the
+    # plain-HTTP request, so probe_http_ssl is 0 and fail_if_not_ssl marks the
+    # probe failed - which silences cert expiry alerting for this domain even
+    # though probe_ssl_earliest_cert_expiry is scraped fine.
+    monitor::domains { $_domain:
+      domain => "https://${_domain}",
+    }
   } else {
     $ports.each |$port| {
       monitor::domains { "${_domain}_${port}":


### PR DESCRIPTION
A manual cert with no ports registered its blackbox target as a bare hostname. Without a scheme, blackbox scores the plain-HTTP request, so probe_http_ssl is 0 and fail_if_not_ssl fails the probe. The expiry metric is still scraped, but the cert_expiry alert guards on probe_success == 1 and drops it, so the cert silently stops being alerted on.

This is how an expired cert on osrepo.hearing.corp-ad.com went unnoticed. The target served HTTP 200, so the domain status alert stayed quiet too.

certs::manual was the only place registering a bare hostname; its own ports branch and all of web::apache already pass https://.

Also monitor the domain the cert is deployed for rather than its CN. The caller already passes domain => the hiera title, but the define ignored it, leaving a documented parameter dead. Normalise casing in monitor::domains so a hostname differing only in case cannot yield a second probe target and a second threshold rule.