### PR TITLE
fix: bypass legacy letsencrypt facts in sort_domains_on_tld for native acme

### DIFF
--- a/modules/enableit/eit_haproxy/manifests/basic_config.pp
+++ b/modules/enableit/eit_haproxy/manifests/basic_config.pp
@@ -234,7 +234,7 @@ class eit_haproxy::basic_config (
 
     if $_use_native_acme {
       # Add Native ACME Monitoring which will loop and directly call monitor::domains
-      sort_domains_on_tld($alldomains, $public_ips).each |$cn, $san| {
+      sort_domains_on_tld($alldomains, $public_ips, true).each |$cn, $san| {
         if $cn == 'rejected_domains' {
           if $san.size > 0 {
             notify { "These domains got rejected because its not pointing to correct server = ${san}": }

--- a/modules/enableit/eit_haproxy/manifests/native_acme.pp
+++ b/modules/enableit/eit_haproxy/manifests/native_acme.pp
@@ -129,7 +129,7 @@ class eit_haproxy::native_acme (
   # Build the entries list once, render the whole crt-list from a template.
   $_entries = $_managed_groups.map |$group_name, $opts| {
     $_safe = regsubst($group_name, /[^a-zA-Z0-9.-]/, '_', 'G')
-    $_sorted_map = sort_domains_on_tld($opts['domains'], $_public_ips)
+    $_sorted_map = sort_domains_on_tld($opts['domains'], $_public_ips, true)
     $_sorted = $_sorted_map.map |$cn, $san| {
       if $cn != 'rejected_domains' { $san }
     }.flatten.delete_undef_values.unique

--- a/modules/enableit/functions/lib/puppet/functions/sort_domains_on_tld.rb
+++ b/modules/enableit/functions/lib/puppet/functions/sort_domains_on_tld.rb
@@ -65,6 +65,7 @@ Puppet::Functions.create_function(:sort_domains_on_tld) do
   dispatch :sort_domains_on_tld do
     required_param 'Array', :args
     optional_param 'Array', :ips
+    optional_param 'Boolean', :ignore_existing_cns
   end
 
   def letsencrypt_cert_cn
@@ -116,12 +117,12 @@ Puppet::Functions.create_function(:sort_domains_on_tld) do
     end
   end
 
-  def sort_domains_on_tld(args, ips = [])
+  def sort_domains_on_tld(args, ips = [], ignore_existing_cns = false)
     cn_domains  = Hash.new
     san_domains = Hash.new
     tld_domains = Hash.new { |h, k| h[k] = Hash.new(&h.default_proc) }
 
-    cns = letsencrypt_cert_cn
+    cns = ignore_existing_cns ? [] : letsencrypt_cert_cn
 
     # Check if the domain is pointing to correct host.
     # If not, then remove that domain from the list


### PR DESCRIPTION
- Add `ignore_existing_cns` parameter to `sort_domains_on_tld` function
- Pass `true` for `ignore_existing_cns` in HAProxy 3.2 native ACME and basic config manifests to prevent stale `letsencrypt_directory` facts from forcing incorrect CN resolution and matching domain monitoring/threshold `.prom` files correctly.

Signed-off-by: Sidharth Jawale <sidharth@obmondo.com>