### PR TITLE
fix(apache): default vhost port so vhosts bind an address

### DIFF
--- a/modules/enableit/eit_types/types/web/apache/vhost_options.pp
+++ b/modules/enableit/eit_types/types/web/apache/vhost_options.pp
@@ -6,6 +6,7 @@ type Eit_types::Web::Apache::Vhost_options = Struct[{
   docroot         => Variant[Stdlib::Unixpath, Boolean],
   domains         => Optional[Array[Stdlib::Fqdn]],
   port            => Optional[Stdlib::Port],
+  servername      => Optional[Stdlib::Fqdn],
   redirect_dest   => Optional[Array[String]],
   redirect_status => Optional[Array[String]],
   serveraliases   => Optional[Array],

--- a/modules/enableit/profile/manifests/web/apache.pp
+++ b/modules/enableit/profile/manifests/web/apache.pp
@@ -12,7 +12,9 @@ class profile::web::apache (
     if $https { 443 },
     if $http { 80 },
     $vhosts.map |$_, $_params| {
-      $_params['port']
+      # `port` is optional in Eit_types::Web::Apache::Vhost_options; fall back to
+      # the scheme default so the firewall still opens the port the vhost binds.
+      pick($_params['port'], $_params['ssl'] ? { true => 443, default => 80 })
     },
   ].flatten.delete_undef_values.sort.unique
 
@@ -84,6 +86,12 @@ class profile::web::apache (
 
   # Setup customers virtualhosts
   unwrap($vhosts).each |$vhost_name, $params| {
+    # `port` is optional, but apache::vhost falls back to the resource title when
+    # it is undef, emitting `<VirtualHost ${vhost_name}>`. Apache then cannot
+    # resolve that as an address and drops the vhost entirely:
+    #   AH00547: Could not resolve host name <name> -- ignoring!
+    $_port = pick($params['port'], $params['ssl'] ? { true => 443, default => 80 })
+
     if $params['ssl'] {
       file {
         "/etc/ssl/private/${vhost_name}":
@@ -107,8 +115,8 @@ class profile::web::apache (
 
       if ! $params['domains'].empty {
         $params['domains'].map |$domain| {
-          monitor::domains { "${domain}_${params['port']}":
-            domain => "https://${domain}:${params['port']}",
+          monitor::domains { "${domain}_${_port}":
+            domain => "https://${domain}:${_port}",
           }
         }
       } elsif ! $domains.empty {
@@ -127,7 +135,11 @@ class profile::web::apache (
 
     apache::vhost { $vhost_name:
       ssl             => $params['ssl'],
-      port            => $params['port'],
+      port            => $_port,
+      # Defaults to the resource title, which is rarely a resolvable hostname, so
+      # the vhost never matches a real `Host:` header and requests fall through to
+      # the default vhost instead.
+      servername      => $params['servername'],
       ssl_cert        => if $params['ssl'] { "/etc/ssl/private/${vhost_name}/cert.pem" },
       ssl_key         => if $params['ssl'] { "/etc/ssl/private/${vhost_name}/cert.key" },
       docroot         => $params['docroot'],


### PR DESCRIPTION
`port` is Optional in Eit_types::Web::Apache::Vhost_options, and the profile passed it straight to apache::vhost. When unset, apache::vhost falls back to the resource title for the vhost address, emitting `<VirtualHost keyserver_webapp>`. Apache cannot resolve that as an address and drops the vhost entirely:

  AH00547: Could not resolve host name keyserver_webapp -- ignoring!

Every request then falls through to the default vhost. Hit in prod on dkcphcochlear0{1,2}: the keyserver app vanished and clients got the default docroot's directory index.

Default the port to 443/80 based on `ssl`, and use it in three places:

- apache::vhost's `port`, which is the actual fix
- the $listen_ports map, so a portless vhost still opens its firewall port instead of relying on $https/$http happening to cover it
- monitor::domains, which was building `https://host:` with a trailing colon whenever port was unset

Also add an optional `servername` passthrough. It defaults to the resource title, which is rarely a resolvable hostname, so a vhost named for the app rather than the site never matches a real Host: header. Leaving it undef keeps the previous behaviour.