### PR TITLE
eit_repos::yum::centos_base: use vault archive for CentOS < 8

### DIFF
--- a/modules/enableit/eit_repos/manifests/yum/centos_base.pp
+++ b/modules/enableit/eit_repos/manifests/yum/centos_base.pp
@@ -14,9 +14,14 @@ class eit_repos::yum::centos_base (
     }
 
     $_os = $facts['os']
-    $_repo_parameters = "${_os['name']}-${_os['release']['major']}" ? {
-      'CentOS-6' => {
-        baseurl => "http://vault.centos.org/${_os['release']['full']}/${_repo}/\$basearch/",
+
+    # CentOS 7 and older are EOL: mirrorlist.centos.org no longer resolves and
+    # the packages only remain on the vault archive. Newer CentOS keeps the
+    # mirrorlist.
+    $_repo_parameters = ($_os['name'] == 'CentOS' and Integer($_os['release']['major']) < 8) ? {
+      true    => {
+        baseurl    => "http://vault.centos.org/${_os['release']['full']}/${_repo}/\$basearch/",
+        mirrorlist => 'absent',
       },
       default => {
         mirrorlist => "http://mirrorlist.centos.org/?release=\$releasever&arch=\$basearch&repo=${_repo}",


### PR DESCRIPTION
CentOS 7 and older are EOL: mirrorlist.centos.org no longer resolves, so base/extras/updates failed with "Could not resolve host". When os.name == CentOS and os.release.major < 8, point the repos at vault.centos.org/<full-release>/ and set mirrorlist => 'absent' so the dead line is stripped from the sections shipped by centos-release. CentOS 8+ / Stream are unchanged (mirrorlist).
